### PR TITLE
Custom tar

### DIFF
--- a/lib/poise_languages/static/mixin.rb
+++ b/lib/poise_languages/static/mixin.rb
@@ -30,6 +30,7 @@ module PoiseLanguages
         poise_languages_static static_folder do
           source url
           strip_components options['strip_components']
+          tar options['tar']
         end
       end
 
@@ -87,6 +88,8 @@ module PoiseLanguages
             strip_components: static_strip_components,
             # URL template to download from.
             url: static_url,
+            # Location of the tar executable, if it's in a non-standard location
+            tar: 'tar'
           })
         end
 

--- a/lib/poise_languages/static/resource.rb
+++ b/lib/poise_languages/static/resource.rb
@@ -51,6 +51,10 @@ module PoiseLanguages
       #   Value to pass to tar --strip-components.
       #   @return [String, Integer, nil]
       attribute(:strip_components, kind_of: [String, Integer, NilClass], default: 1)
+      # @!attribute tar
+      #   Full path of tar executables, in case its in a non-standard location.
+      #   @raturn [String]
+      attribute(:tar, kind_of: String, default: 'tar')
 
       def cache_path
         @cache_path ||= ::File.join(Chef::Config[:file_cache_path], source.split(/\//).last)
@@ -93,7 +97,7 @@ module PoiseLanguages
 
       def install_utils
         package [].tap {|utils|
-          utils << 'tar' if new_resource.cache_path =~ /\.t(ar|gz|bz|xz)/
+          utils << new_resource.tar if new_resource.cache_path =~ /\.t(ar|gz|bz|xz)/
           utils << 'bzip2' if new_resource.cache_path =~ /\.t?bz/
           # This probably won't work on RHEL?
           utils << 'xz-utils' if new_resource.cache_path =~ /\.t?xz/
@@ -125,8 +129,8 @@ module PoiseLanguages
       def unpack_archive
         # Build up the unpack command. Someday this will probably need to
         # support unzip too.
-        cmd = %w{tar}
-        cmd << "--strip-components=#{new_resource.strip_components}" if new_resource.strip_components && new_resource.strip_components > 0
+        cmd = new_resource.tar
+        cmd << "--strip-components=#{new_resource.strip_components}" if new_resource.strip_components && new_resource.strip_components > 0 && !new_resource.is_gnu_tar
         cmd << if new_resource.cache_path =~ /\.t?gz/
           '-xzvf'
         elsif new_resource.cache_path =~ /\.t?bz/

--- a/lib/poise_languages/static/resource.rb
+++ b/lib/poise_languages/static/resource.rb
@@ -129,7 +129,7 @@ module PoiseLanguages
       def unpack_archive
         # Build up the unpack command. Someday this will probably need to
         # support unzip too.
-        cmd = new_resource.tar
+        cmd = [new_resource.tar]
         cmd << "--strip-components=#{new_resource.strip_components}" if new_resource.strip_components && new_resource.strip_components > 0
         cmd << if new_resource.cache_path =~ /\.t?gz/
           '-xzvf'

--- a/lib/poise_languages/static/resource.rb
+++ b/lib/poise_languages/static/resource.rb
@@ -97,7 +97,8 @@ module PoiseLanguages
 
       def install_utils
         package [].tap {|utils|
-          utils << new_resource.tar if new_resource.cache_path =~ /\.t(ar|gz|bz|xz)/
+          # If we're using a custom tar, we shouldn't try to install it.
+          utils << new_resource.tar if new_resource.cache_path =~ /\.t(ar|gz|bz|xz)/ && new_resource.tar == 'tar'
           utils << 'bzip2' if new_resource.cache_path =~ /\.t?bz/
           # This probably won't work on RHEL?
           utils << 'xz-utils' if new_resource.cache_path =~ /\.t?xz/

--- a/lib/poise_languages/static/resource.rb
+++ b/lib/poise_languages/static/resource.rb
@@ -130,7 +130,7 @@ module PoiseLanguages
         # Build up the unpack command. Someday this will probably need to
         # support unzip too.
         cmd = new_resource.tar
-        cmd << "--strip-components=#{new_resource.strip_components}" if new_resource.strip_components && new_resource.strip_components > 0 && !new_resource.is_gnu_tar
+        cmd << "--strip-components=#{new_resource.strip_components}" if new_resource.strip_components && new_resource.strip_components > 0
         cmd << if new_resource.cache_path =~ /\.t?gz/
           '-xzvf'
         elsif new_resource.cache_path =~ /\.t?bz/


### PR DESCRIPTION
Allow users of downstream cookbooks to specify custom location for the tar executable. If a custom tar is used, then no attempt to install tar will be made.