### PR TITLE
Do not mess with scl repos if package is already available

### DIFF
--- a/lib/poise_languages/scl/resource.rb
+++ b/lib/poise_languages/scl/resource.rb
@@ -69,8 +69,10 @@ module PoiseLanguages
       # @return [void]
       def action_install
         notifying_block do
-          install_scl_repo
-          flush_yum_cache
+          if Chef::Provider::Package::Yum::YumCache.instance.available_version(new_resource.package_name).nil?
+            install_scl_repo
+            flush_yum_cache
+          end
           install_scl_package(:install)
           install_scl_devel_package(:install) if new_resource.dev_package
         end
@@ -81,8 +83,10 @@ module PoiseLanguages
       # @return [void]
       def action_upgrade
         notifying_block do
-          install_scl_repo
-          flush_yum_cache
+          if Chef::Provider::Package::Yum::YumCache.instance.available_version(new_resource.package_name).nil?
+            install_scl_repo
+            flush_yum_cache
+          end
           install_scl_package(:upgrade)
           install_scl_devel_package(:upgrade) if new_resource.dev_package
         end


### PR DESCRIPTION
Sometimes packages and yum repos are managed outside the "standard" mechanisms (e.g. RHSM). The existing SCL code (at least for RHEL) always insists on checking for and enabling a specific repo vis RHSM.

This patch and supports alternate repo strategies by checking to see if the package we want is already available (in Chef's YUM cache) before messing with repos. This also happens to avoid excess YUM cache flushes. So as long as a prior cookbook/recipe or existing config makes the appropriate RPM available, now poise won't mess with (and possibly break) yum repos/subscriptions.